### PR TITLE
Fix digit filtering in CleanString

### DIFF
--- a/pkg/str/str.go
+++ b/pkg/str/str.go
@@ -2,13 +2,12 @@ package str
 
 import (
 	"strings"
-	"unicode"
 )
 
 func CleanString(value string) string {
 	var b strings.Builder
 	for _, r := range value {
-		if unicode.IsDigit(r) {
+		if r >= '0' && r <= '9' {
 			b.WriteRune(r)
 		}
 	}


### PR DESCRIPTION
## Summary
- fix CleanString to filter only ASCII digits

## Testing
- `go test ./pkg/str` *(fails: toolchain download blocked)*
- `GOTOOLCHAIN=local go test ./pkg/str` *(fails: go.mod requires go >= 1.24.2)*

------
https://chatgpt.com/codex/tasks/task_e_684834ed0b04832b9913267bf30dedc8