### PR TITLE
Fix swagger tag formatting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,28 +6,28 @@ import (
 )
 
 type config struct {
-	Log         LogConfig         `envPrefix:"LOG_"`
-	Database    DatabaseConfig    `envPrefix:"DB_"`
-	HTTPServer  HTTPServerConfig  `envPrefix:"HTTP_SERVER_"`
-	JwtToken    JwtTokenConfig    `envPrefix:"JWT_"`
-	FileStorage FileStorageConfig `envPrefix:"FILE_STORAGE_"`
+	Log         Log         `envPrefix:"LOG_"`
+	Database    Database    `envPrefix:"DB_"`
+	HTTPServer  HTTPServer  `envPrefix:"HTTP_SERVER_"`
+	JwtToken    JwtToken    `envPrefix:"JWT_"`
+	FileStorage FileStorage `envPrefix:"FILE_STORAGE_"`
 }
 
 type Interface interface {
-	DatabaseConfig() DatabaseConfig
-	HTTPServerConfig() HTTPServerConfig
-	JwtTokenConfig() JwtTokenConfig
-	FileStorageConfig() FileStorageConfig
-	LogConfig() LogConfig
+	Database() Database
+	HTTPServer() HTTPServer
+	JwtToken() JwtToken
+	FileStorage() FileStorage
+	Log() Log
 }
 
-type LogConfig struct {
+type Log struct {
 	Level  string `env:"LOG_LEVEL" default:"info"`
 	Path   string `env:"LOG_PATH" default:"logs/app.log"`
 	Stdout bool   `env:"LOG_STDOUT" default:"true"`
 }
 
-type DatabaseConfig struct {
+type Database struct {
 	Host            string `env:"HOST" envDefault:"localhost"`
 	Port            string `env:"PORT" envDefault:"5432"`
 	User            string `env:"USER" envDefault:"user"`
@@ -39,23 +39,23 @@ type DatabaseConfig struct {
 	ConnMaxLifetime int    `env:"CONN_MAX_LIFETIME" envDefault:"300"`
 }
 
-type HTTPServerConfig struct {
+type HTTPServer struct {
 	Port            string `env:"PORT" envDefault:"8000"`
 	ReadTimeout     int    `env:"READ_TIMEOUT" envDefault:"15"`
 	WriteTimeout    int    `env:"WRITE_TIMEOUT" envDefault:"15"`
 	IdleTimeout     int    `env:"IDLE_TIMEOUT" envDefault:"60"`
 	RateLimit       string `env:"RATE_LIMIT" envDefault:"100-S"`
 	Environment     string `env:"ENVIRONMENT" envDefault:"development"`
-	SwaggerUser     string `env:"SWAGGER_USER", envDefault:"admin"`
-	SwaggerPassword string `env:"SWAGGER_PASSWORD", envDefault:"admin123"`
+	SwaggerUser     string `env:"SWAGGER_USER" envDefault:"admin"`
+	SwaggerPassword string `env:"SWAGGER_PASSWORD" envDefault:"admin123"`
 }
 
-type JwtTokenConfig struct {
+type JwtToken struct {
 	SecretKey        string `env:"SECRET_KEY" envDefault:"3891aSDk23aSDa3j#@sd"`
 	SecretRefreshKey string `env:"REFRESH_SECRET_KEY" envDefault:"h3i12iaSD32u98da@#%aisd"`
 }
 
-type FileStorageConfig struct {
+type FileStorage struct {
 	AccessKey string `env:"FILE_STORAGE_ACCESS_KEY" envDefault:"admin"`
 	SecretKey string `env:"FILE_STORAGE_SECRET_KEY" envDefault:"admin"`
 	Endpoint  string `env:"FILE_STORAGE_ENDPOINT" envDefault:"http://localhost:9000"`
@@ -75,22 +75,22 @@ func New() (Interface, error) {
 	return cfg, nil
 }
 
-func (c *config) LogConfig() LogConfig {
+func (c *config) Log() Log {
 	return c.Log
 }
 
-func (c *config) DatabaseConfig() DatabaseConfig {
+func (c *config) Database() Database {
 	return c.Database
 }
 
-func (c *config) HTTPServerConfig() HTTPServerConfig {
+func (c *config) HTTPServer() HTTPServer {
 	return c.HTTPServer
 }
 
-func (c *config) JwtTokenConfig() JwtTokenConfig {
+func (c *config) JwtToken() JwtToken {
 	return c.JwtToken
 }
 
-func (c *config) FileStorageConfig() FileStorageConfig {
+func (c *config) FileStorage() FileStorage {
 	return c.FileStorage
 }

--- a/config/module.go
+++ b/config/module.go
@@ -5,20 +5,20 @@ import "go.uber.org/fx"
 var Module = fx.Options(
 	fx.Provide(
 		New,
-		func(cfg Interface) LogConfig {
-			return cfg.LogConfig()
+		func(cfg Interface) Log {
+			return cfg.Log()
 		},
-		func(cfg Interface) DatabaseConfig {
-			return cfg.DatabaseConfig()
+		func(cfg Interface) Database {
+			return cfg.Database()
 		},
-		func(cfg Interface) HTTPServerConfig {
-			return cfg.HTTPServerConfig()
+		func(cfg Interface) HTTPServer {
+			return cfg.HTTPServer()
 		},
-		func(cfg Interface) JwtTokenConfig {
-			return cfg.JwtTokenConfig()
+		func(cfg Interface) JwtToken {
+			return cfg.JwtToken()
 		},
-		func(cfg Interface) FileStorageConfig {
-			return cfg.FileStorageConfig()
+		func(cfg Interface) FileStorage {
+			return cfg.FileStorage()
 		},
 	),
 )

--- a/internal/adapter/in/http/http.go
+++ b/internal/adapter/in/http/http.go
@@ -32,7 +32,7 @@ const (
 type server struct {
 	router *gin.Engine
 	srv    *http.Server
-	config config.HTTPServerConfig
+	config config.HTTPServer
 	logger logger.Interface
 }
 
@@ -43,7 +43,7 @@ type ServerInterface interface {
 }
 
 func New(
-	httpConfig config.HTTPServerConfig,
+	httpConfig config.HTTPServer,
 	logger logger.Interface,
 ) ServerInterface {
 	setupGinMode(httpConfig)
@@ -103,7 +103,7 @@ func (s *server) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func setupGinMode(httpConfig config.HTTPServerConfig) {
+func setupGinMode(httpConfig config.HTTPServer) {
 	if httpConfig.Environment != "development" {
 		gin.SetMode(gin.ReleaseMode)
 		return
@@ -111,7 +111,7 @@ func setupGinMode(httpConfig config.HTTPServerConfig) {
 	gin.SetMode(gin.DebugMode)
 }
 
-func setupRouter(httpConfig config.HTTPServerConfig, logger logger.Interface) *gin.Engine {
+func setupRouter(httpConfig config.HTTPServer, logger logger.Interface) *gin.Engine {
 	router := gin.New()
 
 	router.Use(gin.CustomRecovery(func(c *gin.Context, recovered interface{}) {

--- a/internal/adapter/in/http/module.go
+++ b/internal/adapter/in/http/module.go
@@ -12,7 +12,7 @@ import (
 var Module = fx.Options(
 	fx.Provide(
 		func(cfg config.Interface, log logger.Interface) ServerInterface {
-			return New(cfg.HTTPServerConfig(), log)
+			return New(cfg.HTTPServer(), log)
 		},
 	),
 	fx.Invoke(func(lc fx.Lifecycle, server ServerInterface) {

--- a/internal/provider/database/database.go
+++ b/internal/provider/database/database.go
@@ -14,7 +14,7 @@ import (
 
 type database struct {
 	pool   *pgxpool.Pool
-	config config.DatabaseConfig
+	config config.Database
 	logger logger.Interface
 }
 
@@ -24,7 +24,7 @@ type Interface interface {
 	Close()
 }
 
-func New(config config.DatabaseConfig, logger logger.Interface) (Interface, error) {
+func New(config config.Database, logger logger.Interface) (Interface, error) {
 	logger.Logger().Info("initializing database connection...")
 	dsn := getConnectionString(config)
 
@@ -96,7 +96,7 @@ func (d *database) Pool() *pgxpool.Pool {
 	return d.pool
 }
 
-func getConnectionString(config config.DatabaseConfig) string {
+func getConnectionString(config config.Database) string {
 	return fmt.Sprintf("user=%s password=%s dbname=%s port=%s host=%s sslmode=%s",
 		config.User,
 		config.Password,

--- a/internal/provider/database/module.go
+++ b/internal/provider/database/module.go
@@ -11,7 +11,7 @@ import (
 
 var Module = fx.Options(
 	fx.Provide(
-		func(cfg config.DatabaseConfig, log logger.Interface) (Interface, error) {
+		func(cfg config.Database, log logger.Interface) (Interface, error) {
 			return New(cfg, log)
 		},
 	),

--- a/internal/provider/filestorage/filestorage.go
+++ b/internal/provider/filestorage/filestorage.go
@@ -14,7 +14,7 @@ import (
 
 type fileStorage struct {
 	client *s3.S3
-	config config.FileStorageConfig
+	config config.FileStorage
 	logger logger.Interface
 }
 
@@ -25,7 +25,7 @@ type Interface interface {
 	CreateBucket() error
 }
 
-func New(cfg config.FileStorageConfig, logger logger.Interface) (Interface, error) {
+func New(cfg config.FileStorage, logger logger.Interface) (Interface, error) {
 	logger.Logger().Info("initializing file storage connection...")
 
 	sess, err := session.NewSession(&aws.Config{

--- a/internal/provider/filestorage/module.go
+++ b/internal/provider/filestorage/module.go
@@ -10,7 +10,7 @@ import (
 )
 
 var Module = fx.Options(
-	fx.Provide(func(cfg config.FileStorageConfig, log logger.Interface) (Interface, error) {
+	fx.Provide(func(cfg config.FileStorage, log logger.Interface) (Interface, error) {
 		return New(cfg, log)
 	}),
 	fx.Invoke(func(lc fx.Lifecycle, fs Interface) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -19,7 +19,7 @@ type Interface interface {
 	WithContext(ctx context.Context) *slog.Logger
 }
 
-func New(config config.LogConfig) Interface {
+func New(config config.Log) Interface {
 	var level slog.Level
 	switch config.Level {
 	case "debug":

--- a/pkg/logger/module.go
+++ b/pkg/logger/module.go
@@ -6,7 +6,7 @@ import (
 )
 
 var Module = fx.Options(
-	fx.Provide(func(cfg config.LogConfig) Interface {
+	fx.Provide(func(cfg config.Log) Interface {
 		return New(cfg)
 	}),
 )


### PR DESCRIPTION
## Summary
- clean up struct tag formatting for swagger user/password
- drop redundant `Config` suffixes from the config types

## Testing
- `go vet ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684accafe764832babd05510bcdd1762