### PR TITLE
Fix log config parsing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,9 +22,9 @@ type Interface interface {
 }
 
 type Log struct {
-	Level  string `env:"LOG_LEVEL" default:"info"`
-	Path   string `env:"LOG_PATH" default:"logs/app.log"`
-	Stdout bool   `env:"LOG_STDOUT" default:"true"`
+	Level  string `env:"LEVEL" envDefault:"info"`
+	Path   string `env:"PATH" envDefault:"logs/app.log"`
+	Stdout bool   `env:"STDOUT" envDefault:"true"`
 }
 
 type Database struct {


### PR DESCRIPTION
## Summary
- fix Log config tags so env variables load correctly

## Testing
- `make lint` *(fails: unsupported version of configuration)*
- `make test` *(fails: proxy access forbidden for go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684ad66e6bc4832bb9aa3067f8c99c44