### PR TITLE
Improve logger configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ JWT_REFRESH_SECRET_KEY="98312jk#@SDAwseDA@sdj2s"
 LOG_LEVEL=debug
 LOG_PATH=logs/app.log
 LOG_STDOUT=true
+LOG_MAX_SIZE=10
+LOG_MAX_BACKUPS=5
+LOG_MAX_AGE=28
+LOG_COMPRESS=true
 
 # File Storage (MinIO / S3 Compatible)
 FILE_STORAGE_ACCESS_KEY=adminsecret

--- a/config/config.go
+++ b/config/config.go
@@ -22,9 +22,13 @@ type Interface interface {
 }
 
 type Log struct {
-	Level  string `env:"LEVEL" envDefault:"info"`
-	Path   string `env:"PATH" envDefault:"logs/app.log"`
-	Stdout bool   `env:"STDOUT" envDefault:"true"`
+	Level      string `env:"LEVEL" envDefault:"info"`
+	Path       string `env:"PATH" envDefault:"logs/app.log"`
+	Stdout     bool   `env:"STDOUT" envDefault:"true"`
+	MaxSize    int    `env:"MAX_SIZE" envDefault:"10"`
+	MaxBackups int    `env:"MAX_BACKUPS" envDefault:"5"`
+	MaxAge     int    `env:"MAX_AGE" envDefault:"28"`
+	Compress   bool   `env:"COMPRESS" envDefault:"true"`
 }
 
 type Database struct {

--- a/internal/adapter/in/http/middleware.go
+++ b/internal/adapter/in/http/middleware.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/unrolled/secure"
 
+	"github.com/felipeversiane/donation-server/pkg/contextkey"
 	"github.com/felipeversiane/donation-server/pkg/logger"
 )
 
@@ -46,10 +47,10 @@ func logMiddleware(log logger.Interface) gin.HandlerFunc {
 func contextMiddleware(log logger.Interface) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		reqID := uuid.New().String()
-		ctx := context.WithValue(c.Request.Context(), "request_id", reqID)
+		ctx := context.WithValue(c.Request.Context(), contextkey.RequestID, reqID)
 
 		if userID := c.GetHeader("X-User-ID"); userID != "" {
-			ctx = context.WithValue(ctx, "user_id", userID)
+			ctx = context.WithValue(ctx, contextkey.UserID, userID)
 		}
 
 		c.Request = c.Request.WithContext(ctx)

--- a/pkg/contextkey/contextkey.go
+++ b/pkg/contextkey/contextkey.go
@@ -1,0 +1,9 @@
+package contextkey
+
+// Key defines a context key type for request-scoped values.
+type Key string
+
+const (
+	RequestID Key = "request_id"
+	UserID    Key = "user_id"
+)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/felipeversiane/donation-server/config"
+	"github.com/felipeversiane/donation-server/pkg/contextkey"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -46,10 +47,10 @@ func New(config config.Log) Interface {
 
 	fileWriter := &lumberjack.Logger{
 		Filename:   config.Path,
-		MaxSize:    10,
-		MaxBackups: 5,
-		MaxAge:     28,
-		Compress:   true,
+		MaxSize:    config.MaxSize,
+		MaxBackups: config.MaxBackups,
+		MaxAge:     config.MaxAge,
+		Compress:   config.Compress,
 	}
 
 	var output io.Writer
@@ -74,10 +75,10 @@ func (l *logger) WithContext(ctx context.Context) *slog.Logger {
 	}
 
 	fields := []any{}
-	if rid, ok := ctx.Value("request_id").(string); ok {
+	if rid, ok := ctx.Value(contextkey.RequestID).(string); ok {
 		fields = append(fields, "request_id", rid)
 	}
-	if uid, ok := ctx.Value("user_id").(string); ok {
+	if uid, ok := ctx.Value(contextkey.UserID).(string); ok {
 		fields = append(fields, "user_id", uid)
 	}
 

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,70 @@
+package logger_test
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/felipeversiane/donation-server/config"
+	loggerpkg "github.com/felipeversiane/donation-server/pkg/logger"
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+func TestLoggerInitialization(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "app.log")
+	cfg := config.Log{
+		Level:      "error",
+		Path:       logPath,
+		Stdout:     false,
+		MaxSize:    1,
+		MaxBackups: 2,
+		MaxAge:     3,
+		Compress:   false,
+	}
+
+	l := loggerpkg.New(cfg)
+	l.Logger().Debug("debug message")
+	l.Logger().Error("error message")
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+
+	if !reflect.DeepEqual(true, len(data) > 0) {
+		t.Fatalf("expected log file to contain data")
+	}
+
+	if string(data) == "" || !slogEnabled(l.Logger(), slog.LevelError) {
+		t.Fatalf("logger did not log at expected level")
+	}
+
+	lj := extractLumberjackWriter(t, l)
+	if lj.Filename != logPath || lj.MaxSize != cfg.MaxSize || lj.MaxBackups != cfg.MaxBackups || lj.MaxAge != cfg.MaxAge || lj.Compress != cfg.Compress {
+		t.Fatalf("lumberjack config mismatch")
+	}
+}
+
+func slogEnabled(l *slog.Logger, level slog.Level) bool {
+	return l.Handler().Enabled(nil, level)
+}
+
+func extractLumberjackWriter(t *testing.T, l loggerpkg.Interface) *lumberjack.Logger {
+	h := l.Logger().Handler()
+	jh, ok := h.(*slog.JSONHandler)
+	if !ok {
+		t.Fatalf("unexpected handler type %T", h)
+	}
+	v := reflect.ValueOf(jh).Elem().FieldByName("commonHandler")
+	v = reflect.Indirect(v)
+	w := v.FieldByName("w").Interface()
+
+	lj, ok := w.(*lumberjack.Logger)
+	if !ok {
+		t.Fatalf("writer is %T, want *lumberjack.Logger", w)
+	}
+	return lj
+}


### PR DESCRIPTION
## Summary
- add typed context keys
- configure log rotation via config
- wire typed keys in middleware and logger
- document new env vars
- add basic logger tests

## Testing
- `GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24.2)*

------
https://chatgpt.com/codex/tasks/task_e_684f356bbe78832b94326ffbd62d51a0