### PR TITLE
Improve logger interface

### DIFF
--- a/internal/adapter/in/http/http.go
+++ b/internal/adapter/in/http/http.go
@@ -78,10 +78,10 @@ func (s *server) InitRoutes() {
 }
 
 func (s *server) Start() error {
-	s.logger.Logger().Info(MsgStartingHTTPServer, "port", s.config.Port)
+	s.logger.Info(MsgStartingHTTPServer, "port", s.config.Port)
 
 	if err := s.srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		s.logger.Logger().Error(ErrServerFailedToStart, "error", err)
+		s.logger.Error(ErrServerFailedToStart, "error", err)
 		return err
 	}
 
@@ -89,17 +89,17 @@ func (s *server) Start() error {
 }
 
 func (s *server) Shutdown(ctx context.Context) error {
-	s.logger.Logger().Info(MsgInitiatingShutdown)
+	s.logger.Info(MsgInitiatingShutdown)
 
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	if err := s.srv.Shutdown(ctx); err != nil {
-		s.logger.Logger().Error(ErrShutdownFailed, "error", err)
+		s.logger.Error(ErrShutdownFailed, "error", err)
 		return err
 	}
 
-	s.logger.Logger().Info(MsgShutdownSuccessful)
+	s.logger.Info(MsgShutdownSuccessful)
 	return nil
 }
 
@@ -115,7 +115,7 @@ func setupRouter(httpConfig config.HTTPServer, logger logger.Interface) *gin.Eng
 	router := gin.New()
 
 	router.Use(gin.CustomRecovery(func(c *gin.Context, recovered interface{}) {
-		logger.Logger().Error(ErrPanicRecovered, "error", recovered)
+		logger.Error(ErrPanicRecovered, "error", recovered)
 		c.AbortWithStatus(500)
 	}))
 

--- a/internal/provider/database/database.go
+++ b/internal/provider/database/database.go
@@ -25,36 +25,36 @@ type Interface interface {
 }
 
 func New(config config.Database, logger logger.Interface) (Interface, error) {
-	logger.Logger().Info("initializing database connection...")
+	logger.Info("initializing database connection...")
 	dsn := getConnectionString(config)
 
 	poolConfig, err := pgxpool.ParseConfig(dsn)
 	if err != nil {
-		logger.Logger().Error("error parsing pool config", "error", err)
+		logger.Error("error parsing pool config", "error", err)
 		return nil, fmt.Errorf("error parsing pool config: %w", err)
 	}
 
 	maxConns, err := number.SafeIntToInt32(config.MaxConnections)
 	if err != nil {
-		logger.Logger().Error("invalid max connections", "error", err)
+		logger.Error("invalid max connections", "error", err)
 		return nil, fmt.Errorf("invalid max connections: %w", err)
 	}
 	poolConfig.MaxConns = maxConns
 
 	minConns, err := number.SafeIntToInt32(config.MinConnections)
 	if err != nil {
-		logger.Logger().Error("invalid min connections", "error", err)
+		logger.Error("invalid min connections", "error", err)
 		return nil, fmt.Errorf("invalid min connections: %w", err)
 	}
 	poolConfig.MinConns = minConns
 
 	poolConfig.MaxConnLifetime = time.Duration(config.ConnMaxLifetime) * time.Second
 
-	logger.Logger().Info("creating database connection pool...")
+	logger.Info("creating database connection pool...")
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), poolConfig)
 	if err != nil {
-		logger.Logger().Error("error creating connection pool", "error", err)
+		logger.Error("error creating connection pool", "error", err)
 		return nil, fmt.Errorf("error creating connection pool: %w", err)
 	}
 
@@ -64,15 +64,15 @@ func New(config config.Database, logger logger.Interface) (Interface, error) {
 		logger: logger,
 	}
 
-	logger.Logger().Info("attempting to ping database")
+	logger.Info("attempting to ping database")
 
 	if err := db.Ping(context.Background()); err != nil {
 		db.Close()
-		logger.Logger().Error("error pinging database", "error", err)
+		logger.Error("error pinging database", "error", err)
 		return nil, fmt.Errorf("error pinging database: %w", err)
 	}
 
-	logger.Logger().Info("database connection established successfully")
+	logger.Info("database connection established successfully")
 
 	return db, nil
 }
@@ -88,7 +88,7 @@ func (d *database) Ping(ctx context.Context) error {
 func (d *database) Close() {
 	if d.pool != nil {
 		d.pool.Close()
-		d.logger.Logger().Info("database connection closed")
+		d.logger.Info("database connection closed")
 	}
 }
 

--- a/internal/provider/filestorage/filestorage.go
+++ b/internal/provider/filestorage/filestorage.go
@@ -26,7 +26,7 @@ type Interface interface {
 }
 
 func New(cfg config.FileStorage, logger logger.Interface) (Interface, error) {
-	logger.Logger().Info("initializing file storage connection...")
+	logger.Info("initializing file storage connection...")
 
 	sess, err := session.NewSession(&aws.Config{
 		Region:           aws.String(cfg.Region),
@@ -35,7 +35,7 @@ func New(cfg config.FileStorage, logger logger.Interface) (Interface, error) {
 		S3ForcePathStyle: aws.Bool(true),
 	})
 	if err != nil {
-		logger.Logger().Error("unable to create S3 session", "error", err)
+		logger.Error("unable to create S3 session", "error", err)
 		return nil, fmt.Errorf("unable to create S3 session: %w", err)
 	}
 
@@ -47,7 +47,7 @@ func New(cfg config.FileStorage, logger logger.Interface) (Interface, error) {
 		logger: logger,
 	}
 
-	logger.Logger().Info("file storage initialized successfully")
+	logger.Info("file storage initialized successfully")
 
 	return fs, nil
 }
@@ -73,20 +73,20 @@ func (f *fileStorage) CreateBucket() error {
 	})
 
 	if err == nil {
-		f.logger.Logger().Info("bucket already exists", "bucket", bucket)
+		f.logger.Info("bucket already exists", "bucket", bucket)
 		return nil
 	}
 
 	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NotFound" {
-		f.logger.Logger().Warn("bucket not found, creating", "bucket", bucket)
+		f.logger.Warn("bucket not found, creating", "bucket", bucket)
 		_, err = client.CreateBucket(&s3.CreateBucketInput{
 			Bucket: aws.String(bucket),
 		})
 		if err != nil {
-			f.logger.Logger().Error("failed to create bucket", "bucket", bucket, "error", err)
+			f.logger.Error("failed to create bucket", "bucket", bucket, "error", err)
 			return fmt.Errorf("failed to create bucket %s: %w", bucket, err)
 		}
-		f.logger.Logger().Info("bucket created successfully", "bucket", bucket)
+		f.logger.Info("bucket created successfully", "bucket", bucket)
 		return nil
 	}
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -17,9 +17,20 @@ type logger struct {
 	slog *slog.Logger
 }
 
+// Interface exposes common logging capabilities in a form similar to slog.Logger
+// while also allowing log enrichment with request scoped values.
 type Interface interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
+	With(args ...any) Interface
+	WithGroup(name string) Interface
+	Handler() slog.Handler
+	WithContext(ctx context.Context) Interface
+
+	// Logger returns the underlying slog.Logger for advanced use cases.
 	Logger() *slog.Logger
-	WithContext(ctx context.Context) *slog.Logger
 }
 
 func New(config config.Log) Interface {
@@ -69,9 +80,9 @@ func New(config config.Log) Interface {
 	return &logger{slog: s}
 }
 
-func (l *logger) WithContext(ctx context.Context) *slog.Logger {
+func (l *logger) WithContext(ctx context.Context) Interface {
 	if ctx == nil {
-		return l.slog
+		return l
 	}
 
 	fields := []any{}
@@ -82,9 +93,37 @@ func (l *logger) WithContext(ctx context.Context) *slog.Logger {
 		fields = append(fields, "user_id", uid)
 	}
 
-	return l.slog.With(fields...)
+	return &logger{slog: l.slog.With(fields...)}
 }
 
 func (l *logger) Logger() *slog.Logger {
 	return l.slog
+}
+
+func (l *logger) Debug(msg string, args ...any) {
+	l.slog.Debug(msg, args...)
+}
+
+func (l *logger) Info(msg string, args ...any) {
+	l.slog.Info(msg, args...)
+}
+
+func (l *logger) Warn(msg string, args ...any) {
+	l.slog.Warn(msg, args...)
+}
+
+func (l *logger) Error(msg string, args ...any) {
+	l.slog.Error(msg, args...)
+}
+
+func (l *logger) With(args ...any) Interface {
+	return &logger{slog: l.slog.With(args...)}
+}
+
+func (l *logger) WithGroup(name string) Interface {
+	return &logger{slog: l.slog.WithGroup(name)}
+}
+
+func (l *logger) Handler() slog.Handler {
+	return l.slog.Handler()
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -26,8 +26,8 @@ func TestLoggerInitialization(t *testing.T) {
 	}
 
 	l := loggerpkg.New(cfg)
-	l.Logger().Debug("debug message")
-	l.Logger().Error("error message")
+	l.Debug("debug message")
+	l.Error("error message")
 
 	data, err := os.ReadFile(logPath)
 	if err != nil {
@@ -38,7 +38,7 @@ func TestLoggerInitialization(t *testing.T) {
 		t.Fatalf("expected log file to contain data")
 	}
 
-	if string(data) == "" || !slogEnabled(l.Logger(), slog.LevelError) {
+	if string(data) == "" || !slogEnabled(l, slog.LevelError) {
 		t.Fatalf("logger did not log at expected level")
 	}
 
@@ -48,12 +48,12 @@ func TestLoggerInitialization(t *testing.T) {
 	}
 }
 
-func slogEnabled(l *slog.Logger, level slog.Level) bool {
+func slogEnabled(l loggerpkg.Interface, level slog.Level) bool {
 	return l.Handler().Enabled(nil, level)
 }
 
 func extractLumberjackWriter(t *testing.T, l loggerpkg.Interface) *lumberjack.Logger {
-	h := l.Logger().Handler()
+	h := l.Handler()
 	jh, ok := h.(*slog.JSONHandler)
 	if !ok {
 		t.Fatalf("unexpected handler type %T", h)


### PR DESCRIPTION
## Summary
- expose logging methods directly on the logger interface
- refactor packages to use the new interface
- adjust logger tests for new usage

## Testing
- `env GOTOOLCHAIN=local go test ./...` *(fails: go.mod requires go >= 1.24.2)*

------
https://chatgpt.com/codex/tasks/task_e_684f3a537688832b8caed23a395684fe