### PR TITLE
Propagate logger dir creation error

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,6 +6,10 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"os"
+
 	"github.com/felipeversiane/donation-server/config"
 	"github.com/felipeversiane/donation-server/internal/adapter/in/http"
 	"github.com/felipeversiane/donation-server/internal/provider/database"
@@ -23,5 +27,14 @@ func main() {
 		fx.NopLogger,
 	)
 
-	app.Run()
+	ctx := context.Background()
+	if err := app.Start(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start application: %v\n", err)
+		os.Exit(1)
+	}
+	<-app.Done()
+	if err := app.Stop(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stop application: %v\n", err)
+		os.Exit(1)
+	}
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -33,7 +33,7 @@ type Interface interface {
 	Logger() *slog.Logger
 }
 
-func New(config config.Log) Interface {
+func New(config config.Log) (Interface, error) {
 	var level slog.Level
 	switch config.Level {
 	case "debug":
@@ -53,7 +53,7 @@ func New(config config.Log) Interface {
 
 	dir := filepath.Dir(config.Path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		panic(fmt.Sprintf("failed to create log directory: %v", err))
+		return nil, fmt.Errorf("failed to create log directory: %w", err)
 	}
 
 	fileWriter := &lumberjack.Logger{
@@ -71,13 +71,10 @@ func New(config config.Log) Interface {
 		output = fileWriter
 	}
 
-	var handler slog.Handler
-
-	handler = slog.NewJSONHandler(output, opts)
-
+	handler := slog.NewJSONHandler(output, opts)
 	s := slog.New(handler)
 
-	return &logger{slog: s}
+	return &logger{slog: s}, nil
 }
 
 func (l *logger) WithContext(ctx context.Context) Interface {

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -25,7 +25,10 @@ func TestLoggerInitialization(t *testing.T) {
 		Compress:   false,
 	}
 
-	l := loggerpkg.New(cfg)
+	l, err := loggerpkg.New(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	l.Debug("debug message")
 	l.Error("error message")
 

--- a/pkg/logger/module.go
+++ b/pkg/logger/module.go
@@ -6,7 +6,7 @@ import (
 )
 
 var Module = fx.Options(
-	fx.Provide(func(cfg config.Log) Interface {
+	fx.Provide(func(cfg config.Log) (Interface, error) {
 		return New(cfg)
 	}),
 )


### PR DESCRIPTION
## Summary
- return `(logger.Interface, error)` from `logger.New`
- update logger module provider signature
- handle startup error in `cmd/main.go`
- adjust logger tests for new signature

## Testing
- `go test ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_685064836d80832b8467a6522001d044