### PR TITLE
Fix postgres backup entrypoint

### DIFF
--- a/docker/Dockerfile.pg
+++ b/docker/Dockerfile.pg
@@ -23,11 +23,9 @@ RUN echo 'CREATE EXTENSION IF NOT EXISTS vector;' > /docker-entrypoint-initdb.d/
 COPY docker/backup.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/backup.sh
 
-RUN echo "${BACKUP_SCHEDULE} postgres BACKUP_PASSWORD=\${BACKUP_PASSWORD} BACKUP_DIR=\${BACKUP_DIR} MAX_BACKUPS=\${MAX_BACKUPS} BACKUP_LOG_FILE=\${BACKUP_LOG_FILE} /usr/local/bin/backup.sh >> \${BACKUP_LOG_FILE} 2>&1" > /etc/cron.d/postgres-backup \
-  && chmod 0644 /etc/cron.d/postgres-backup
+COPY docker/postgres-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/postgres-entrypoint.sh
 
-RUN echo '#!/bin/bash\nservice cron start\nexec docker-entrypoint.sh "$@"' > /docker-entrypoint.sh \
-  && chmod +x /docker-entrypoint.sh
-
-ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["postgres"] 
+USER root
+ENTRYPOINT ["/usr/local/bin/postgres-entrypoint.sh"]
+CMD ["postgres"]

--- a/docker/postgres-entrypoint.sh
+++ b/docker/postgres-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Configure cron job using runtime env vars
+printf "%s postgres BACKUP_PASSWORD=%s BACKUP_DIR=%s MAX_BACKUPS=%s BACKUP_LOG_FILE=%s /usr/local/bin/backup.sh >> %s 2>&1\n" \ 
+  "${BACKUP_SCHEDULE}" "${BACKUP_PASSWORD}" "${BACKUP_DIR}" "${MAX_BACKUPS}" "${BACKUP_LOG_FILE}" "${BACKUP_LOG_FILE}" > /etc/cron.d/postgres-backup
+chmod 0644 /etc/cron.d/postgres-backup
+
+# Start cron service
+service cron start
+
+exec docker-entrypoint.sh "$@"
+


### PR DESCRIPTION
## Summary
- ensure postgres image runs backup cronjob with runtime environment variables
- add runtime entrypoint script to start cron

## Testing
- `go test ./... -v` *(fails: golang download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68506e489c1c832baf7d365ab0e95b88