### PR TITLE
Insert pipefail in backup script

### DIFF
--- a/docker/backup.sh
+++ b/docker/backup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
 MAX_BACKUPS="${MAX_BACKUPS:-7}"


### PR DESCRIPTION
## Summary
- set `-euo pipefail` at the top of `docker/backup.sh`

## Testing
- `go test ./... -v` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850720f4d38832bbd59b69334db94b9