### PR TITLE
Refine logger context utilities

### DIFF
--- a/internal/adapter/in/http/middleware.go
+++ b/internal/adapter/in/http/middleware.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"context"
 	"log/slog"
 	"time"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/unrolled/secure"
 
-	"github.com/felipeversiane/donation-server/pkg/contextkey"
 	"github.com/felipeversiane/donation-server/pkg/logger"
 )
 
@@ -47,10 +45,10 @@ func logMiddleware(log logger.Interface) gin.HandlerFunc {
 func contextMiddleware(log logger.Interface) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		reqID := uuid.New().String()
-		ctx := context.WithValue(c.Request.Context(), contextkey.RequestID, reqID)
+		ctx := logger.ContextWithRequestID(c.Request.Context(), reqID)
 
 		if userID := c.GetHeader("X-User-ID"); userID != "" {
-			ctx = context.WithValue(ctx, contextkey.UserID, userID)
+			ctx = logger.ContextWithUserID(ctx, userID)
 		}
 
 		c.Request = c.Request.WithContext(ctx)

--- a/pkg/contextkey/contextkey.go
+++ b/pkg/contextkey/contextkey.go
@@ -1,9 +1,0 @@
-package contextkey
-
-// Key defines a context key type for request-scoped values.
-type Key string
-
-const (
-	RequestID Key = "request_id"
-	UserID    Key = "user_id"
-)

--- a/pkg/logger/context.go
+++ b/pkg/logger/context.go
@@ -1,0 +1,35 @@
+package logger
+
+import "context"
+
+// contextKey is an unexported type for keys defined in this package.
+type contextKey string
+
+const (
+	// RequestIDKey stores a unique request identifier in the context.
+	RequestIDKey contextKey = "request_id"
+	// UserIDKey stores an authenticated user identifier in the context.
+	UserIDKey contextKey = "user_id"
+)
+
+// ContextWithRequestID returns a new context with the request id set.
+func ContextWithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, RequestIDKey, id)
+}
+
+// ContextWithUserID returns a new context with the user id set.
+func ContextWithUserID(ctx context.Context, userID string) context.Context {
+	return context.WithValue(ctx, UserIDKey, userID)
+}
+
+// RequestIDFromContext retrieves the request id from the context.
+func RequestIDFromContext(ctx context.Context) (string, bool) {
+	rid, ok := ctx.Value(RequestIDKey).(string)
+	return rid, ok
+}
+
+// UserIDFromContext retrieves the user id from the context.
+func UserIDFromContext(ctx context.Context) (string, bool) {
+	uid, ok := ctx.Value(UserIDKey).(string)
+	return uid, ok
+}

--- a/pkg/logger/context_test.go
+++ b/pkg/logger/context_test.go
@@ -1,0 +1,21 @@
+package logger
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContextWithRequestIDAndUserID(t *testing.T) {
+	ctx := context.Background()
+	ctx = ContextWithRequestID(ctx, "req123")
+	ctx = ContextWithUserID(ctx, "user456")
+
+	rid, ok := RequestIDFromContext(ctx)
+	if !ok || rid != "req123" {
+		t.Fatalf("RequestIDFromContext=%q, ok=%v", rid, ok)
+	}
+	uid, ok := UserIDFromContext(ctx)
+	if !ok || uid != "user456" {
+		t.Fatalf("UserIDFromContext=%q, ok=%v", uid, ok)
+	}
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/felipeversiane/donation-server/config"
-	"github.com/felipeversiane/donation-server/pkg/contextkey"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -90,10 +89,10 @@ func (l *logger) WithContext(ctx context.Context) Interface {
 	}
 
 	fields := []any{}
-	if rid, ok := ctx.Value(contextkey.RequestID).(string); ok {
+	if rid, ok := RequestIDFromContext(ctx); ok {
 		fields = append(fields, "request_id", rid)
 	}
-	if uid, ok := ctx.Value(contextkey.UserID).(string); ok {
+	if uid, ok := UserIDFromContext(ctx); ok {
 		fields = append(fields, "user_id", uid)
 	}
 


### PR DESCRIPTION
## Summary
- inline context key helpers in logger
- remove contextkey package
- update middleware to use new helpers
- add tests for context helper functions

## Testing
- `go test ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850d257bc98832ba2a825c5eb45e2ff