### PR TITLE
Fix Makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,5 @@ setup:
 	@git config core.hooksPath .githooks
 
 test:
-        go test ./... -v
+	go test ./... -v
 


### PR DESCRIPTION
## Summary
- fix indentation in the `test` recipe in Makefile so that make can parse it

## Testing
- `make build` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850db473280832b94d5b3f8ac3b612d