### PR TITLE
Fix lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: "2"
 run:
   timeout: 3m
   tests: true
@@ -17,9 +18,6 @@ linters:
     - exhaustive
     - forcetypeassert
     - funlen
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - gosec
     - ineffassign
@@ -35,10 +33,14 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
 
 linters-settings:
   goimports:

--- a/internal/provider/filestorage/filestorage.go
+++ b/internal/provider/filestorage/filestorage.go
@@ -1,6 +1,7 @@
 package filestorage
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -77,7 +78,8 @@ func (f *fileStorage) CreateBucket() error {
 		return nil
 	}
 
-	if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NotFound" {
+	var aerr awserr.Error
+	if errors.As(err, &aerr) && aerr.Code() == "NotFound" {
 		f.logger.Warn("bucket not found, creating", "bucket", bucket)
 		_, err = client.CreateBucket(&s3.CreateBucketInput{
 			Bucket: aws.String(bucket),

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,13 +1,14 @@
 package logger
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 
-	"github.com/felipeversiane/donation-server/config"	
+	"github.com/felipeversiane/donation-server/config"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -36,22 +37,32 @@ func TestLoggerInitialization(t *testing.T) {
 		t.Fatalf("failed to read log file: %v", err)
 	}
 
-	if !reflect.DeepEqual(true, len(data) > 0) {
+	if len(data) == 0 {
 		t.Fatalf("expected log file to contain data")
 	}
 
-	if string(data) == "" || !slogEnabled(l, slog.LevelError) {
+	if string(data) == "" {
+		t.Fatalf("logger did not write to file")
+	}
+	if !slogEnabled(l, slog.LevelError) {
 		t.Fatalf("logger did not log at expected level")
 	}
 
 	lj := extractLumberjackWriter(t, l)
-	if lj.Filename != logPath || lj.MaxSize != cfg.MaxSize || lj.MaxBackups != cfg.MaxBackups || lj.MaxAge != cfg.MaxAge || lj.Compress != cfg.Compress {
+	expected := lumberjack.Logger{
+		Filename:   logPath,
+		MaxSize:    cfg.MaxSize,
+		MaxBackups: cfg.MaxBackups,
+		MaxAge:     cfg.MaxAge,
+		Compress:   cfg.Compress,
+	}
+	if !reflect.DeepEqual(*lj, expected) {
 		t.Fatalf("lumberjack config mismatch")
 	}
 }
 
 func slogEnabled(l Interface, level slog.Level) bool {
-	return l.Handler().Enabled(nil, level)
+	return l.Handler().Enabled(context.TODO(), level)
 }
 
 func extractLumberjackWriter(t *testing.T, l Interface) *lumberjack.Logger {


### PR DESCRIPTION
## Summary
- clean up logger tests
- use `errors.As` for AWS error check
- update linter configuration for v2 schema

## Testing
- `golangci-lint run --config=.golangci.yml` *(fails: go.mod requires go >= 1.24.2)*

------
https://chatgpt.com/codex/tasks/task_e_68514db38944832bb74a06bb8e774a86